### PR TITLE
feat: tenant-keyed config schema (v0.2.0)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,58 +2,59 @@ auth_mode: lax
 cors_allow_origins: ["*"]
 admin_token: change-me-in-real-deployments
 
-users:
-  alice:
-    password: alice-pw
-    upn: alice@example.com
-    preferred_username: alice@example.com
-    oid: 11111111-1111-1111-1111-aaaaaaaaaaaa
-    tid: 22222222-2222-2222-2222-222222222222
-    token_version: v2
-    token_lifetime_seconds: 300
-    roles: [operator, responder]
-    groups: [platform-team]
-    allowed_audiences:
-      - api://serviceB
-      - api://serviceC
-    extra_claims:
-      department: engineering
-      cost_center: cc-1234
+tenants:
+  22222222-2222-2222-2222-222222222222:
+    users:
+      alice:
+        password: alice-pw
+        upn: alice@example.com
+        preferred_username: alice@example.com
+        oid: 11111111-1111-1111-1111-aaaaaaaaaaaa
+        token_version: v2
+        token_lifetime_seconds: 300
+        roles: [operator, responder]
+        groups: [platform-team]
+        allowed_audiences:
+          - api://serviceB
+          - api://serviceC
+        extra_claims:
+          department: engineering
+          cost_center: cc-1234
 
-  bob:
-    password: bob-pw
-    upn: bob@example.com
-    preferred_username: bob@example.com
-    oid: 11111111-1111-1111-1111-bbbbbbbbbbbb
-    token_version: v2
-    token_lifetime_seconds: 300
-    roles: [metrics-reader]
-    groups: [analytics-team]
-    allowed_audiences: [api://serviceB]
+      bob:
+        password: bob-pw
+        upn: bob@example.com
+        preferred_username: bob@example.com
+        oid: 11111111-1111-1111-1111-bbbbbbbbbbbb
+        token_version: v2
+        token_lifetime_seconds: 300
+        roles: [metrics-reader]
+        groups: [analytics-team]
+        allowed_audiences: [api://serviceB]
 
-clients:
-  service-a:
-    client_id: 01010101-1010-1010-1010-aaaaaaaaaaaa
-    secret: serviceA-secret
-    label: ServiceA
-    token_version: v1
-    token_lifetime_seconds: 3600
-    roles: [m2m]
-    groups: [service-accounts]
-    allowed_audiences: [api://serviceB]
-    extra_claims:
-      tier: 1
+    clients:
+      service-a:
+        client_id: 01010101-1010-1010-1010-aaaaaaaaaaaa
+        secret: serviceA-secret
+        label: ServiceA
+        token_version: v1
+        token_lifetime_seconds: 3600
+        roles: [m2m]
+        groups: [service-accounts]
+        allowed_audiences: [api://serviceB]
+        extra_claims:
+          tier: 1
 
-  service-b:
-    client_id: 02020202-2020-2020-2020-bbbbbbbbbbbb
-    secret: serviceB-secret
-    label: ServiceB
-    token_version: v1
-    roles: [m2m]
-    groups: [service-accounts]
-    allowed_audiences: [api://serviceC]
+      service-b:
+        client_id: 02020202-2020-2020-2020-bbbbbbbbbbbb
+        secret: serviceB-secret
+        label: ServiceB
+        token_version: v1
+        roles: [m2m]
+        groups: [service-accounts]
+        allowed_audiences: [api://serviceC]
 
-  "00000000-0000-0000-0000-000000000000":
-    secret: admin-secret
-    label: TestAdmin
-    override_any_claim: true
+      "00000000-0000-0000-0000-000000000000":
+        secret: admin-secret
+        label: TestAdmin
+        override_any_claim: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mock-idp"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.1",

--- a/src/mock_idp/config.py
+++ b/src/mock_idp/config.py
@@ -23,16 +23,24 @@ MODE: str = _config.auth_mode
 # without touching the ConfigMap.
 ADMIN_TOKEN: str = os.getenv("MOCK_IDP_ADMIN_TOKEN") or _config.admin_token
 CORS_ORIGINS: list[str] = _config.cors_allow_origins
-USERS: dict[str, UserRecord] = _config.users
 
+USERS: dict[str, UserRecord] = {}
 CLIENTS: dict[str, ClientRecord] = {}
-for _key, _rec in _config.clients.items():
-    _canonical = _rec.client_id or _key
-    _rec._canonical_id = _canonical
-    CLIENTS[_key] = _rec
-    if _canonical != _key:
-        CLIENTS[_canonical] = _rec
+_raw_client_keys: set[str] = set()
+
+for _tid, _tenant in _config.tenants.items():
+    for _username, _user in _tenant.users.items():
+        _user.tid = _tid
+        USERS[_username] = _user
+    for _key, _rec in _tenant.clients.items():
+        _rec.tid = _tid
+        _canonical = _rec.client_id or _key
+        _rec._canonical_id = _canonical
+        CLIENTS[_key] = _rec
+        _raw_client_keys.add(_key)
+        if _canonical != _key:
+            CLIENTS[_canonical] = _rec
 
 _clients_raw: dict[str, ClientRecord] = {
-    k: v for k, v in CLIENTS.items() if k in _config.clients
+    k: v for k, v in CLIENTS.items() if k in _raw_client_keys
 }

--- a/src/mock_idp/models.py
+++ b/src/mock_idp/models.py
@@ -8,7 +8,7 @@ class UserRecord(BaseModel):
     upn: Optional[str] = None
     preferred_username: Optional[str] = None
     oid: str = "00000000-0000-0000-0000-000000000000"
-    tid: str = "22222222-2222-2222-2222-222222222222"
+    tid: str = ""  # injected from tenant key at load time
     token_version: str = "v2"
     token_lifetime_seconds: int = 3600
     roles: list[str] = []
@@ -34,7 +34,7 @@ class ClientRecord(BaseModel):
     token_lifetime_seconds: int = 3600
     roles: list[str] = []
     groups: list[str] = []
-    tid: str = "22222222-2222-2222-2222-222222222222"
+    tid: str = ""  # injected from tenant key at load time
     allowed_audiences: list[str] = []
     extra_claims: dict[str, Any] = {}
     override_any_claim: bool = False
@@ -48,12 +48,16 @@ class ClientRecord(BaseModel):
         return v
 
 
+class TenantRecord(BaseModel):
+    users: dict[str, UserRecord] = {}
+    clients: dict[str, ClientRecord] = {}
+
+
 class AppConfig(BaseModel):
     auth_mode: str = "lax"
     cors_allow_origins: list[str] = ["*"]
     admin_token: str = "change-me"
-    users: dict[str, UserRecord] = {}
-    clients: dict[str, ClientRecord] = {}
+    tenants: dict[str, TenantRecord] = {}
 
     @field_validator("auth_mode")
     @classmethod

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ wheels = [
 
 [[package]]
 name = "mock-idp"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

- Replaces flat `users:` / `clients:` top-level keys with `tenants: {<tid>: {users: ..., clients: ...}}`
- `tid` (tenant UUID) is now the grouping key — no longer repeated on every user and client record
- Config loader flattens tenants into the existing `USERS`/`CLIENTS` dicts so all router/token code is unchanged
- Bumps version to `0.2.0`

**Breaking change**: configs using the old flat schema must be migrated to the new `tenants:` structure.

## Test plan

- [x] All 31 existing tests pass with the new schema
- [x] `tid` is correctly injected into JWT claims from the tenant key
- [x] `debug/identities` still returns flat `users` and `clients` dicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)