### PR TITLE
feat: v0.3 provider plugin architecture and Entra ID grants model

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,8 @@ admin_token: change-me-in-real-deployments
 
 tenants:
   22222222-2222-2222-2222-222222222222:
+    provider: entra_id
+
     users:
       alice:
         password: alice-pw
@@ -12,7 +14,6 @@ tenants:
         oid: 11111111-1111-1111-1111-aaaaaaaaaaaa
         token_version: v2
         token_lifetime_seconds: 300
-        roles: [operator, responder]
         groups: [platform-team]
         allowed_audiences:
           - api://serviceB
@@ -28,18 +29,16 @@ tenants:
         oid: 11111111-1111-1111-1111-bbbbbbbbbbbb
         token_version: v2
         token_lifetime_seconds: 300
-        roles: [metrics-reader]
         groups: [analytics-team]
         allowed_audiences: [api://serviceB]
 
-    clients:
+    service_principals:
       service-a:
         client_id: 01010101-1010-1010-1010-aaaaaaaaaaaa
         secret: serviceA-secret
         label: ServiceA
         token_version: v1
         token_lifetime_seconds: 3600
-        roles: [m2m]
         groups: [service-accounts]
         allowed_audiences: [api://serviceB]
         extra_claims:
@@ -50,7 +49,6 @@ tenants:
         secret: serviceB-secret
         label: ServiceB
         token_version: v1
-        roles: [m2m]
         groups: [service-accounts]
         allowed_audiences: [api://serviceC]
 
@@ -58,3 +56,20 @@ tenants:
         secret: admin-secret
         label: TestAdmin
         override_any_claim: true
+
+    clients:
+      api://serviceB:
+        app_id: 01010101-1010-1010-1010-bbbbbbbbbbbb
+        label: Service B API
+        roles: [operator, responder, m2m]
+        grants:
+          alice: [operator, responder]
+          service-a: [m2m]
+
+      api://serviceC:
+        app_id: 02020202-2020-2020-2020-cccccccccccc
+        label: Service C API
+        roles: [reader, admin, m2m]
+        grants:
+          alice: [reader]
+          service-b: [m2m]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mock-idp"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.1",

--- a/src/mock_idp/config.py
+++ b/src/mock_idp/config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import yaml
 
-from .models import AppConfig, ClientRecord, UserRecord
+from .models import AppConfig, ClientAppRecord, ServicePrincipalRecord, UserRecord
 
 CONFIG_PATH = Path(os.getenv("CONFIG_PATH", "/etc/mock-idp/config.yaml"))
 ISS_BASE = os.getenv("ISS_BASE", "http://localhost:8080")
@@ -25,22 +25,27 @@ ADMIN_TOKEN: str = os.getenv("MOCK_IDP_ADMIN_TOKEN") or _config.admin_token
 CORS_ORIGINS: list[str] = _config.cors_allow_origins
 
 USERS: dict[str, UserRecord] = {}
-CLIENTS: dict[str, ClientRecord] = {}
-_raw_client_keys: set[str] = set()
+SERVICE_PRINCIPALS: dict[str, ServicePrincipalRecord] = {}  # canonical + alias lookup
+CLIENT_APPS: dict[str, ClientAppRecord] = {}  # resource apps keyed by audience URI
+
+_raw_sp_keys: set[str] = set()
 
 for _tid, _tenant in _config.tenants.items():
     for _username, _user in _tenant.users.items():
         _user.tid = _tid
         USERS[_username] = _user
-    for _key, _rec in _tenant.clients.items():
-        _rec.tid = _tid
-        _canonical = _rec.client_id or _key
-        _rec._canonical_id = _canonical
-        CLIENTS[_key] = _rec
-        _raw_client_keys.add(_key)
+    for _key, _sp in _tenant.service_principals.items():
+        _sp.tid = _tid
+        _sp._name = _key
+        _canonical = _sp.client_id or _key
+        _sp._canonical_id = _canonical
+        SERVICE_PRINCIPALS[_key] = _sp
+        _raw_sp_keys.add(_key)
         if _canonical != _key:
-            CLIENTS[_canonical] = _rec
+            SERVICE_PRINCIPALS[_canonical] = _sp
+    for _aud, _app in _tenant.clients.items():
+        CLIENT_APPS[_aud] = _app
 
-_clients_raw: dict[str, ClientRecord] = {
-    k: v for k, v in CLIENTS.items() if k in _raw_client_keys
+_service_principals_raw: dict[str, ServicePrincipalRecord] = {
+    k: v for k, v in SERVICE_PRINCIPALS.items() if k in _raw_sp_keys
 }

--- a/src/mock_idp/models.py
+++ b/src/mock_idp/models.py
@@ -11,7 +11,7 @@ class UserRecord(BaseModel):
     tid: str = ""  # injected from tenant key at load time
     token_version: str = "v2"
     token_lifetime_seconds: int = 3600
-    roles: list[str] = []
+    roles: list[str] = []  # fallback when no client-app grants are configured
     groups: list[str] = []
     allowed_audiences: list[str] = []
     extra_claims: dict[str, Any] = {}
@@ -24,7 +24,9 @@ class UserRecord(BaseModel):
         return v
 
 
-class ClientRecord(BaseModel):
+class ServicePrincipalRecord(BaseModel):
+    """Machine identity that requests tokens (client_credentials grant)."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     client_id: Optional[str] = None
@@ -32,13 +34,14 @@ class ClientRecord(BaseModel):
     label: Optional[str] = None
     token_version: str = "v1"
     token_lifetime_seconds: int = 3600
-    roles: list[str] = []
+    roles: list[str] = []  # fallback when no client-app grants are configured
     groups: list[str] = []
     tid: str = ""  # injected from tenant key at load time
     allowed_audiences: list[str] = []
     extra_claims: dict[str, Any] = {}
     override_any_claim: bool = False
     _canonical_id: str = PrivateAttr(default="")
+    _name: str = PrivateAttr(default="")  # original key in service_principals; used for grants lookup
 
     @field_validator("token_version")
     @classmethod
@@ -48,9 +51,20 @@ class ClientRecord(BaseModel):
         return v
 
 
+class ClientAppRecord(BaseModel):
+    """Resource application — defines available roles and per-identity grants."""
+
+    app_id: Optional[str] = None
+    label: Optional[str] = None
+    roles: list[str] = []
+    grants: dict[str, list[str]] = {}
+
+
 class TenantRecord(BaseModel):
+    provider: str = "entra_id"
     users: dict[str, UserRecord] = {}
-    clients: dict[str, ClientRecord] = {}
+    service_principals: dict[str, ServicePrincipalRecord] = {}
+    clients: dict[str, ClientAppRecord] = {}  # resource apps keyed by audience URI
 
 
 class AppConfig(BaseModel):

--- a/src/mock_idp/providers/__init__.py
+++ b/src/mock_idp/providers/__init__.py
@@ -1,0 +1,15 @@
+"""Provider registry — maps provider name to its claims-building module."""
+
+import importlib
+from types import ModuleType
+
+_REGISTRY: dict[str, str] = {
+    "entra_id": ".entra_id",
+}
+
+
+def get_provider(name: str) -> ModuleType:
+    path = _REGISTRY.get(name)
+    if path is None:
+        raise ValueError(f"Unknown provider {name!r}. Available: {sorted(_REGISTRY)}")
+    return importlib.import_module(path, package=__package__)

--- a/src/mock_idp/providers/entra_id.py
+++ b/src/mock_idp/providers/entra_id.py
@@ -1,0 +1,74 @@
+"""Entra ID (Azure AD) token claim shape — v1 and v2 formats."""
+
+import time
+from typing import Optional
+
+from .. import config as _cfg
+from ..models import ServicePrincipalRecord, UserRecord
+
+
+def _common(issuer: str, aud: str, expires_in: int) -> dict:
+    now = int(time.time())
+    return {
+        "iss": f"{_cfg.ISS_BASE}/{issuer}",
+        "aud": aud,
+        "iat": now,
+        "nbf": now,
+        "exp": now + expires_in,
+    }
+
+
+def user_claims(
+    issuer: str,
+    user: UserRecord,
+    aud: str,
+    shape: str,
+    expires_in: int,
+    roles: list[str],
+    oauth_client_id: Optional[str],
+) -> dict:
+    c = _common(issuer, aud, expires_in)
+    c["sub"] = user.oid
+    c["oid"] = user.oid
+    c["tid"] = user.tid
+    c["roles"] = roles
+    c["groups"] = list(user.groups)
+    if shape == "v1":
+        c["upn"] = user.upn
+        c["unique_name"] = user.upn
+        c["ver"] = "1.0"
+        if oauth_client_id:
+            c["appid"] = oauth_client_id
+    else:
+        c["preferred_username"] = user.preferred_username
+        c["ver"] = "2.0"
+        if oauth_client_id:
+            c["azp"] = oauth_client_id
+    if user.extra_claims:
+        c.update(user.extra_claims)
+    return c
+
+
+def sp_claims(
+    issuer: str,
+    canonical_id: str,
+    sp: ServicePrincipalRecord,
+    aud: str,
+    shape: str,
+    expires_in: int,
+    roles: list[str],
+) -> dict:
+    c = _common(issuer, aud, expires_in)
+    c["sub"] = canonical_id
+    c["tid"] = sp.tid
+    c["roles"] = roles
+    c["groups"] = list(sp.groups)
+    if shape == "v1":
+        c["appid"] = canonical_id
+        c["ver"] = "1.0"
+    else:
+        c["azp"] = canonical_id
+        c["ver"] = "2.0"
+    if sp.extra_claims:
+        c.update(sp.extra_claims)
+    return c

--- a/src/mock_idp/routers/debug.py
+++ b/src/mock_idp/routers/debug.py
@@ -46,7 +46,12 @@ async def debug_decode(body: DecodeRequest):
 async def debug_identities():
     return {
         "users": {k: redact(v.model_dump()) for k, v in _cfg.USERS.items()},
-        "clients": {k: redact(v.model_dump()) for k, v in _cfg._clients_raw.items()},
+        "service_principals": {
+            k: redact(v.model_dump()) for k, v in _cfg._service_principals_raw.items()
+        },
+        "client_apps": {
+            k: v.model_dump() for k, v in _cfg.CLIENT_APPS.items()
+        },
     }
 
 
@@ -57,7 +62,8 @@ async def debug_config():
         "cors_allow_origins": _cfg.CORS_ORIGINS,
         "iss_base": _cfg.ISS_BASE,
         "user_count": len(_cfg.USERS),
-        "client_count": len(_cfg._clients_raw),
+        "service_principal_count": len(_cfg._service_principals_raw),
+        "client_app_count": len(_cfg.CLIENT_APPS),
         "signing_kid": key_kid(get_signing_key()),
         "alt_kid_present": True,
     }

--- a/src/mock_idp/routers/oidc.py
+++ b/src/mock_idp/routers/oidc.py
@@ -6,16 +6,16 @@ from fastapi.responses import JSONResponse
 
 from .. import config as _cfg
 from ..keys import get_alt_key, get_signing_key
+from ..providers import get_provider
 from ..tokens import (
     apply_overrides,
     check_audience,
-    client_claims,
     omit,
     resolve_aud,
     resolve_expiry,
+    resolve_roles,
     resolve_shape,
     sign,
-    user_claims,
 )
 
 router = APIRouter()
@@ -53,26 +53,30 @@ async def token(issuer: str, request: Request):
     headers = {k.lower(): v for k, v in request.headers.items()}
     grant_type = form.get("grant_type")
     aud = resolve_aud(form)
+    provider = get_provider("entra_id")
 
     if grant_type == "password":
-        user = _cfg.USERS.get(form.get("username") or "")
+        user_key = form.get("username") or ""
+        user = _cfg.USERS.get(user_key)
         if not user or user.password != form.get("password"):
             raise HTTPException(401, "invalid_grant")
-        check_audience(user, aud)
+        check_audience(user_key, user, aud)
         shape = resolve_shape(user.token_version, form, headers.get("x-token-shape"))
         expires_in = resolve_expiry(user.token_lifetime_seconds, headers)
-        claims = user_claims(issuer, user, aud, shape, expires_in, form.get("client_id"))
+        roles = resolve_roles(user_key, user, aud)
+        claims = provider.user_claims(issuer, user, aud, shape, expires_in, roles, form.get("client_id"))
 
     elif grant_type == "client_credentials":
-        client_key = form.get("client_id") or ""
-        client = _cfg.CLIENTS.get(client_key)
-        if not client or client.secret != form.get("client_secret"):
+        sp_key = form.get("client_id") or ""
+        sp = _cfg.SERVICE_PRINCIPALS.get(sp_key)
+        if not sp or sp.secret != form.get("client_secret"):
             raise HTTPException(401, "invalid_client")
-        check_audience(client, aud)
-        shape = resolve_shape(client.token_version, form, headers.get("x-token-shape"))
-        expires_in = resolve_expiry(client.token_lifetime_seconds, headers)
-        claims = client_claims(issuer, client._canonical_id, client, aud, shape, expires_in)
-        if client.override_any_claim:
+        check_audience(sp_key, sp, aud)
+        shape = resolve_shape(sp.token_version, form, headers.get("x-token-shape"))
+        expires_in = resolve_expiry(sp.token_lifetime_seconds, headers)
+        roles = resolve_roles(sp_key, sp, aud)
+        claims = provider.sp_claims(issuer, sp._canonical_id, sp, aud, shape, expires_in, roles)
+        if sp.override_any_claim:
             apply_overrides(claims, form)
 
     else:
@@ -93,22 +97,26 @@ async def token_wrong_sig(issuer: str, request: Request):
     form = dict(await request.form())
     headers = {k.lower(): v for k, v in request.headers.items()}
     aud = resolve_aud(form)
+    provider = get_provider("entra_id")
 
     if form.get("grant_type") == "password":
-        user = _cfg.USERS.get(form.get("username") or "")
+        user_key = form.get("username") or ""
+        user = _cfg.USERS.get(user_key)
         if not user or user.password != form.get("password"):
             raise HTTPException(401, "invalid_grant")
-        check_audience(user, aud)
+        check_audience(user_key, user, aud)
         shape = resolve_shape(user.token_version, form, headers.get("x-token-shape"))
-        claims = user_claims(issuer, user, aud, shape, 3600, form.get("client_id"))
+        roles = resolve_roles(user_key, user, aud)
+        claims = provider.user_claims(issuer, user, aud, shape, 3600, roles, form.get("client_id"))
     else:
-        client_key = form.get("client_id") or ""
-        client = _cfg.CLIENTS.get(client_key)
-        if not client or client.secret != form.get("client_secret"):
+        sp_key = form.get("client_id") or ""
+        sp = _cfg.SERVICE_PRINCIPALS.get(sp_key)
+        if not sp or sp.secret != form.get("client_secret"):
             raise HTTPException(401, "invalid_client")
-        check_audience(client, aud)
-        shape = resolve_shape(client.token_version, form, headers.get("x-token-shape"))
-        claims = client_claims(issuer, client._canonical_id, client, aud, shape, 3600)
+        check_audience(sp_key, sp, aud)
+        shape = resolve_shape(sp.token_version, form, headers.get("x-token-shape"))
+        roles = resolve_roles(sp_key, sp, aud)
+        claims = provider.sp_claims(issuer, sp._canonical_id, sp, aud, shape, 3600, roles)
 
     return {
         "access_token": sign(claims, get_alt_key()),

--- a/src/mock_idp/tokens.py
+++ b/src/mock_idp/tokens.py
@@ -1,4 +1,3 @@
-import time
 from typing import Optional
 
 from authlib.jose import JsonWebKey, jwt
@@ -6,7 +5,7 @@ from fastapi import HTTPException
 
 from . import config as _cfg
 from .keys import key_kid
-from .models import ClientRecord, UserRecord
+from .models import ServicePrincipalRecord, UserRecord
 
 _LIST_CLAIMS = {"roles", "groups", "amr"}
 _RESERVED_FORM_FIELDS = {
@@ -51,11 +50,49 @@ def resolve_expiry(default: int, headers: dict) -> int:
     return default or 3600
 
 
-def check_audience(identity: UserRecord | ClientRecord, aud: str) -> None:
+def resolve_roles(identity_key: str, identity: UserRecord | ServicePrincipalRecord, aud: str) -> list[str]:
+    """Resolve roles for the requested audience.
+
+    Uses the client-app grants table when a matching ClientAppRecord exists;
+    falls back to the flat roles list on the identity otherwise.
+    """
+    app = _cfg.CLIENT_APPS.get(aud)
+    if app is not None:
+        # SPs look up grants by their original config name, not by UUID alias
+        grants_key = (
+            identity._name
+            if isinstance(identity, ServicePrincipalRecord) and identity._name
+            else identity_key
+        )
+        return list(app.grants.get(grants_key, []))
+    return list(identity.roles)
+
+
+def check_audience(identity_key: str, identity: UserRecord | ServicePrincipalRecord, aud: str) -> None:
     if _cfg.MODE != "strict":
         return
-    if isinstance(identity, ClientRecord) and identity.override_any_claim:
+    if isinstance(identity, ServicePrincipalRecord) and identity.override_any_claim:
         return
+    app = _cfg.CLIENT_APPS.get(aud)
+    if app is not None:
+        # grants model: reject if this identity has no grant on the app
+        grants_key = (
+            identity._name
+            if isinstance(identity, ServicePrincipalRecord) and identity._name
+            else identity_key
+        )
+        if grants_key not in app.grants:
+            raise HTTPException(
+                400,
+                detail={
+                    "error": "invalid_target",
+                    "error_description": (
+                        f"Identity {identity_key!r} has no grant on {aud!r}."
+                    ),
+                },
+            )
+        return
+    # flat model fallback: check allowed_audiences
     if aud not in identity.allowed_audiences:
         raise HTTPException(
             400,
@@ -66,71 +103,6 @@ def check_audience(identity: UserRecord | ClientRecord, aud: str) -> None:
                 ),
             },
         )
-
-
-def _common(issuer: str, aud: str, expires_in: int) -> dict:
-    now = int(time.time())
-    return {
-        "iss": f"{_cfg.ISS_BASE}/{issuer}",
-        "aud": aud,
-        "iat": now,
-        "nbf": now,
-        "exp": now + expires_in,
-    }
-
-
-def user_claims(
-    issuer: str,
-    user: UserRecord,
-    aud: str,
-    shape: str,
-    expires_in: int,
-    oauth_client_id: Optional[str],
-) -> dict:
-    c = _common(issuer, aud, expires_in)
-    c["sub"] = user.oid
-    c["oid"] = user.oid
-    c["tid"] = user.tid
-    c["roles"] = list(user.roles)
-    c["groups"] = list(user.groups)
-    if shape == "v1":
-        c["upn"] = user.upn
-        c["unique_name"] = user.upn
-        c["ver"] = "1.0"
-        if oauth_client_id:
-            c["appid"] = oauth_client_id
-    else:
-        c["preferred_username"] = user.preferred_username
-        c["ver"] = "2.0"
-        if oauth_client_id:
-            c["azp"] = oauth_client_id
-    if user.extra_claims:
-        c.update(user.extra_claims)
-    return c
-
-
-def client_claims(
-    issuer: str,
-    canonical_id: str,
-    client: ClientRecord,
-    aud: str,
-    shape: str,
-    expires_in: int,
-) -> dict:
-    c = _common(issuer, aud, expires_in)
-    c["sub"] = canonical_id
-    c["tid"] = client.tid
-    c["roles"] = list(client.roles)
-    c["groups"] = list(client.groups)
-    if shape == "v1":
-        c["appid"] = canonical_id
-        c["ver"] = "1.0"
-    else:
-        c["azp"] = canonical_id
-        c["ver"] = "2.0"
-    if client.extra_claims:
-        c.update(client.extra_claims)
-    return c
 
 
 def apply_overrides(claims: dict, form: dict) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -135,6 +135,54 @@ def test_password_grant_with_client_id_adds_azp(client):
     assert "azp" in payload
 
 
+# ── Grants model ───────────────────────────────────────────────────────────
+
+
+def test_grants_resolve_correct_roles_for_audience(client):
+    """Alice gets operator+responder on serviceB but only reader on serviceC."""
+    r_b = client.post(
+        "/default/token",
+        data={"grant_type": "password", "username": "alice", "password": "alice-pw",
+              "resource": "api://serviceB"},
+    )
+    r_c = client.post(
+        "/default/token",
+        data={"grant_type": "password", "username": "alice", "password": "alice-pw",
+              "resource": "api://serviceC"},
+    )
+    roles_b = _decode_payload(r_b.json()["access_token"])["roles"]
+    roles_c = _decode_payload(r_c.json()["access_token"])["roles"]
+    assert sorted(roles_b) == ["operator", "responder"]
+    assert roles_c == ["reader"]
+
+
+def test_grants_sp_resolves_by_name_not_uuid(client):
+    """service-a grant is resolved even when authenticating with UUID client_id."""
+    r = client.post(
+        "/default/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": "01010101-1010-1010-1010-aaaaaaaaaaaa",
+            "client_secret": "serviceA-secret",
+            "resource": "api://serviceB",
+        },
+    )
+    assert r.status_code == 200
+    payload = _decode_payload(r.json()["access_token"])
+    assert payload["roles"] == ["m2m"]
+
+
+def test_grants_no_grant_returns_empty_roles_in_lax(client):
+    """bob has no grant on serviceC — lax mode returns empty roles, not 400."""
+    r = client.post(
+        "/default/token",
+        data={"grant_type": "password", "username": "bob", "password": "bob-pw",
+              "resource": "api://serviceC"},
+    )
+    assert r.status_code == 200
+    assert _decode_payload(r.json()["access_token"])["roles"] == []
+
+
 # ── Client credentials ─────────────────────────────────────────────────────
 
 
@@ -150,7 +198,6 @@ def test_client_credentials_happy_path(client):
     )
     assert r.status_code == 200
     payload = _decode_payload(r.json()["access_token"])
-    # alias resolves to UUID in token
     assert payload["appid"] == "01010101-1010-1010-1010-aaaaaaaaaaaa"
     assert payload["ver"] == "1.0"
 
@@ -280,6 +327,24 @@ def test_strict_mode_allows_listed_audience(client):
         m.MODE = original
 
 
+def test_strict_mode_rejects_identity_without_grant(client):
+    """bob has no grant on serviceC — strict mode rejects it."""
+    import mock_idp.config as m
+
+    original = m.MODE
+    m.MODE = "strict"
+    try:
+        r = client.post(
+            "/default/token",
+            data={"grant_type": "password", "username": "bob", "password": "bob-pw",
+                  "resource": "api://serviceC"},
+        )
+        assert r.status_code == 400
+        assert r.json()["detail"]["error"] == "invalid_target"
+    finally:
+        m.MODE = original
+
+
 # ── Admin override ─────────────────────────────────────────────────────────
 
 
@@ -350,7 +415,6 @@ def test_wrong_sig_endpoint(client):
         },
     )
     assert r.status_code == 200
-    # kid in token header should NOT match the published JWKS kid
     import base64
     import json as _json
 
@@ -396,8 +460,9 @@ def test_debug_identities_redacts_secrets(client):
     data = r.json()
     for rec in data["users"].values():
         assert rec["password"] == "***"
-    for rec in data["clients"].values():
+    for rec in data["service_principals"].values():
         assert rec["secret"] == "***"
+    assert "client_apps" in data
 
 
 def test_debug_config(client):


### PR DESCRIPTION
## Summary

- **`providers/` module** — registry + `entra_id.py` claims builder extracted from `tokens.py`. Adding a new provider is one file + one registry line.
- **`ServicePrincipalRecord`** replaces `ClientRecord` for machine identities (`client_credentials` grant). Grants are resolved by original config name, not UUID alias.
- **`ClientAppRecord`** models resource apps with defined `roles` and per-identity `grants:`, keyed by audience URI under `tenants.<tid>.clients`.
- **`resolve_roles()`** uses the grants table when a `ClientAppRecord` exists for the requested audience; falls back to flat `roles` on the identity otherwise (backward compatible).
- **`check_audience()`** in strict mode rejects identities with no grant on a known client app; falls back to `allowed_audiences` for unknown audiences.
- **`debug/identities`** now returns `service_principals` and `client_apps` alongside `users`.

## Breaking changes

- `clients:` under a tenant is now **resource apps** (not machine identities)
- Machine identities move to `service_principals:`
- `debug/identities` response key `clients` → `service_principals`

## Test plan

- [x] 35/35 tests passing
- [x] 4 new tests: grants role resolution per-audience, SP UUID alias, empty-grant lax, empty-grant strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)