### PR TITLE
chore: bump to v0.3.2

### DIFF
--- a/docs/mock-oidc/roadmap.md
+++ b/docs/mock-oidc/roadmap.md
@@ -376,9 +376,12 @@ fixture, fresh-start-per-restart is ideal.
   resolve by original config name, not UUID alias. See ADR-002.
 - ✓ **Feature gates are implicit (v0.3)** — presence of `clients:` grants block activates
   grants model; no explicit `features:` flag. Simple config stays simple.
-- ✓ **Playground update (v0.4 candidate)** — audience dropdown from `client_apps`,
-  `service_principals` identity group, resolved-roles display per audience. Deferred
-  until debug endpoint shape stabilises post-v0.3.
+- ✓ **Playground update (v0.3.1)** — audience dropdown from `client_apps`,
+  `service_principals` identity group, resolved-roles display per audience.
+- ✓ **Playground testing overrides + sig verification (v0.3.2)** — collapsible
+  "Testing overrides" panel with `X-Test-Expired` checkbox and `X-Omit-Claims` text
+  input; both headers reflected in the generated curl snippet. Signature verification
+  badge (`✓`/`✗`) in the JWT card, resolved asynchronously via `POST /debug/decode`.
 
 These were once open questions; resolved during v0.2 design:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mock-idp"
-version = "0.3.1"
+version = "0.3.2"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.1",


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version to `0.3.2`
- Adds two resolved entries to the roadmap for the playground improvements shipped since v0.3.1:
  - Playground update (v0.3.1) — audience dropdown, service principals group, grants panel
  - Playground testing overrides + sig verification (v0.3.2) — X-Test-Expired, X-Omit-Claims UI, sig badge

## What's in v0.3.2

| PR | Change |
|---|---|
| #6 | `docs/mock-oidc/hosting-poc.md` — managed k8s hosting PoC guide |
| #7 | Playground: testing overrides panel + signature verification badge |
| #8 | README: status badges + corrected project layout |

🤖 Generated with [Claude Code](https://claude.com/claude-code)