### PR TITLE
feat: gate iss claim override behind override_iss_too flag (v0.3.3)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -56,6 +56,7 @@ tenants:
         secret: admin-secret
         label: TestAdmin
         override_any_claim: true
+        # override_iss_too: true  # uncomment to allow iss claim override (negative iss-validation testing)
 
     clients:
       api://serviceB:

--- a/src/mock_idp/models.py
+++ b/src/mock_idp/models.py
@@ -40,6 +40,7 @@ class ServicePrincipalRecord(BaseModel):
     allowed_audiences: list[str] = []
     extra_claims: dict[str, Any] = {}
     override_any_claim: bool = False
+    override_iss_too: bool = False  # explicit second flag required to override iss
     _canonical_id: str = PrivateAttr(default="")
     _name: str = PrivateAttr(default="")  # original key in service_principals; used for grants lookup
 

--- a/src/mock_idp/routers/oidc.py
+++ b/src/mock_idp/routers/oidc.py
@@ -77,7 +77,7 @@ async def token(issuer: str, request: Request):
         roles = resolve_roles(sp_key, sp, aud)
         claims = provider.sp_claims(issuer, sp._canonical_id, sp, aud, shape, expires_in, roles)
         if sp.override_any_claim:
-            apply_overrides(claims, form)
+            apply_overrides(claims, form, allow_iss=sp.override_iss_too)
 
     else:
         raise HTTPException(400, "unsupported_grant_type")

--- a/src/mock_idp/tokens.py
+++ b/src/mock_idp/tokens.py
@@ -16,6 +16,7 @@ _RESERVED_FORM_FIELDS = {
     "password",
     "resource",
     "scope",
+    "iss",  # gated separately via override_iss_too
 }
 
 
@@ -105,9 +106,15 @@ def check_audience(identity_key: str, identity: UserRecord | ServicePrincipalRec
         )
 
 
-def apply_overrides(claims: dict, form: dict) -> None:
+def apply_overrides(claims: dict, form: dict, allow_iss: bool = False) -> None:
     for k, v in form.items():
-        if not k or k in _RESERVED_FORM_FIELDS:
+        if not k:
+            continue
+        if k == "iss":
+            if allow_iss:
+                claims["iss"] = v
+            continue
+        if k in _RESERVED_FORM_FIELDS:
             continue
         if k in _LIST_CLAIMS and isinstance(v, str):
             claims[k] = [item.strip() for item in v.split(",") if item.strip()]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -366,6 +366,48 @@ def test_admin_override_injects_custom_claims(client):
     assert payload["custom_claim"] == "custom-value"
 
 
+def test_admin_iss_override_blocked_without_flag(client):
+    """iss cannot be overridden unless override_iss_too is also set."""
+    r = client.post(
+        "/default/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": "00000000-0000-0000-0000-000000000000",
+            "client_secret": "admin-secret",
+            "resource": "api://anywhere",
+            "iss": "https://evil.example.com",
+        },
+    )
+    assert r.status_code == 200
+    payload = _decode_payload(r.json()["access_token"])
+    assert payload["iss"] != "https://evil.example.com"
+
+
+def test_admin_iss_override_allowed_with_flag(client):
+    """iss can be overridden when override_iss_too is True."""
+    import mock_idp.config as m
+
+    admin_sp = m.SERVICE_PRINCIPALS["00000000-0000-0000-0000-000000000000"]
+    original = admin_sp.override_iss_too
+    admin_sp.override_iss_too = True
+    try:
+        r = client.post(
+            "/default/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": "00000000-0000-0000-0000-000000000000",
+                "client_secret": "admin-secret",
+                "resource": "api://anywhere",
+                "iss": "https://evil.example.com",
+            },
+        )
+        assert r.status_code == 200
+        payload = _decode_payload(r.json()["access_token"])
+        assert payload["iss"] == "https://evil.example.com"
+    finally:
+        admin_sp.override_iss_too = original
+
+
 # ── Test override headers ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `iss` is now blocked from admin claim overrides by default — it was previously unguarded despite the roadmap intent
- New `override_iss_too: bool = False` field on `ServicePrincipalRecord`
- An SP with `override_any_claim: true` can only override `iss` if it also has `override_iss_too: true`
- Documented as a commented-out option in `config.example.yaml`
- Two new tests: blocked-without-flag and allowed-with-flag

## Use case

```yaml
# config.yaml
service_principals:
  test-admin:
    secret: admin-secret
    override_any_claim: true
    override_iss_too: true   # now required for iss substitution
```

```bash
# Test that your gateway rejects tokens from a foreign issuer
curl -X POST http://localhost:8080/default/token \
  -d "grant_type=client_credentials&client_id=test-admin&client_secret=admin-secret" \
  -d "resource=api://myapp&iss=https://attacker.example.com"
```

## Test plan

- [x] 37/37 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)