### PR TITLE
feat: X-Test-Delay-Ms and X-Test-Fail headers (v0.3.4)

### DIFF
--- a/src/mock_idp/routers/oidc.py
+++ b/src/mock_idp/routers/oidc.py
@@ -9,6 +9,7 @@ from ..keys import get_alt_key, get_signing_key
 from ..providers import get_provider
 from ..tokens import (
     apply_overrides,
+    apply_test_hooks,
     check_audience,
     omit,
     resolve_aud,
@@ -27,7 +28,9 @@ async def healthz():
 
 
 @router.get("/{issuer}/.well-known/openid-configuration")
-async def discovery(issuer: str):
+async def discovery(issuer: str, request: Request):
+    headers = {k.lower(): v for k, v in request.headers.items()}
+    await apply_test_hooks(headers)
     base = f"{_cfg.ISS_BASE}/{issuer}"
     return {
         "issuer": base,
@@ -43,7 +46,9 @@ async def discovery(issuer: str):
 
 
 @router.get("/{issuer}/jwks")
-async def jwks(issuer: str):
+async def jwks(issuer: str, request: Request):
+    headers = {k.lower(): v for k, v in request.headers.items()}
+    await apply_test_hooks(headers)
     return {"keys": [get_signing_key().as_dict(is_private=False)]}
 
 
@@ -51,6 +56,7 @@ async def jwks(issuer: str):
 async def token(issuer: str, request: Request):
     form = dict(await request.form())
     headers = {k.lower(): v for k, v in request.headers.items()}
+    await apply_test_hooks(headers)
     grant_type = form.get("grant_type")
     aud = resolve_aud(form)
     provider = get_provider("entra_id")

--- a/src/mock_idp/tokens.py
+++ b/src/mock_idp/tokens.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Optional
 
 from authlib.jose import JsonWebKey, jwt
@@ -131,6 +132,18 @@ def omit(claims: dict, header_value: Optional[str]) -> None:
     for name in (header_value or "").split(","):
         if name := name.strip():
             claims.pop(name, None)
+
+
+async def apply_test_hooks(headers: dict) -> None:
+    """Honor X-Test-Delay-Ms and X-Test-Fail request headers."""
+    delay_ms = headers.get("x-test-delay-ms")
+    if delay_ms:
+        try:
+            await asyncio.sleep(max(0, int(delay_ms)) / 1000)
+        except (ValueError, TypeError):
+            pass
+    if headers.get("x-test-fail"):
+        raise HTTPException(500, {"error": "server_error", "error_description": "X-Test-Fail triggered"})
 
 
 def redact(d: object) -> object:

--- a/src/playground.html
+++ b/src/playground.html
@@ -272,6 +272,17 @@
           <input type="text" id="test-omit" placeholder="oid,tid" spellcheck="false">
           <div class="hint">Comma-separated claim names to drop from the token</div>
         </div>
+        <div class="field" style="flex:0 0 160px">
+          <label for="test-delay">X-Test-Delay-Ms</label>
+          <input type="number" id="test-delay" placeholder="0" min="0" max="30000">
+          <div class="hint">Delay response by N ms</div>
+        </div>
+        <div class="field" style="flex:0 0 auto;min-width:180px">
+          <label style="display:flex;align-items:center;cursor:pointer">
+            <input type="checkbox" id="test-fail"> X-Test-Fail
+          </label>
+          <div class="hint">Returns HTTP 500 instead of a token</div>
+        </div>
       </div>
     </details>
 
@@ -605,6 +616,15 @@
       if (omitClaims) {
         headers['X-Omit-Claims'] = omitClaims;
         curlHeaderArg += ` \\\n  -H "X-Omit-Claims: ${omitClaims}"`;
+      }
+      const delayMs = $('test-delay')?.value?.trim();
+      if (delayMs && delayMs !== '0') {
+        headers['X-Test-Delay-Ms'] = delayMs;
+        curlHeaderArg += ` \\\n  -H "X-Test-Delay-Ms: ${delayMs}"`;
+      }
+      if ($('test-fail')?.checked) {
+        headers['X-Test-Fail'] = '1';
+        curlHeaderArg += ` \\\n  -H "X-Test-Fail: 1"`;
       }
 
       statusEl.textContent = 'Issuing…';

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -427,6 +427,39 @@ def test_x_test_expired(client):
     assert payload["exp"] < int(time.time())
 
 
+def test_x_test_fail_token(client):
+    r = client.post(
+        "/default/token",
+        headers={"X-Test-Fail": "1"},
+        data={"grant_type": "password", "username": "alice", "password": "alice-pw"},
+    )
+    assert r.status_code == 500
+
+
+def test_x_test_fail_jwks(client):
+    r = client.get("/default/jwks", headers={"X-Test-Fail": "1"})
+    assert r.status_code == 500
+
+
+def test_x_test_fail_discovery(client):
+    r = client.get("/default/.well-known/openid-configuration", headers={"X-Test-Fail": "1"})
+    assert r.status_code == 500
+
+
+def test_x_test_delay_ms(client):
+    import time
+    start = time.monotonic()
+    r = client.post(
+        "/default/token",
+        headers={"X-Test-Delay-Ms": "200"},
+        data={"grant_type": "password", "username": "alice", "password": "alice-pw",
+              "resource": "api://serviceB"},
+    )
+    elapsed_ms = (time.monotonic() - start) * 1000
+    assert r.status_code == 200
+    assert elapsed_ms >= 200
+
+
 def test_x_omit_claims(client):
     r = client.post(
         "/default/token",


### PR DESCRIPTION
## Summary

- `X-Test-Delay-Ms: N` — sleeps N milliseconds before responding; works on `/token`, `/jwks`, and `/.well-known/openid-configuration`
- `X-Test-Fail: 1` — returns HTTP 500 on those same endpoints
- Playground testing overrides panel gains a delay number input and a fail checkbox; both appear in the generated curl snippet
- 4 new tests (fail on token, fail on jwks, fail on discovery, delay adds latency)

## Use case

Test that your gateway handles OIDC provider timeouts and errors gracefully:

```bash
# Confirm gateway retries on 500
curl -H "X-Test-Fail: 1" http://localhost:8080/default/jwks

# Confirm gateway enforces a JWKS-fetch timeout
curl -H "X-Test-Delay-Ms: 6000" http://localhost:8080/default/jwks
```

## Test plan

- [x] 41/41 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)