### PR TITLE
fix: coerce numeric password/secret values to str (ValidationError on startup)

### DIFF
--- a/src/mock_idp/models.py
+++ b/src/mock_idp/models.py
@@ -16,6 +16,11 @@ class UserRecord(BaseModel):
     allowed_audiences: list[str] = []
     extra_claims: dict[str, Any] = {}
 
+    @field_validator("password", mode="before")
+    @classmethod
+    def _coerce_password(cls, v: object) -> str:
+        return str(v)
+
     @field_validator("token_version")
     @classmethod
     def _valid_version(cls, v: str) -> str:
@@ -43,6 +48,11 @@ class ServicePrincipalRecord(BaseModel):
     override_iss_too: bool = False  # explicit second flag required to override iss
     _canonical_id: str = PrivateAttr(default="")
     _name: str = PrivateAttr(default="")  # original key in service_principals; used for grants lookup
+
+    @field_validator("secret", mode="before")
+    @classmethod
+    def _coerce_secret(cls, v: object) -> str:
+        return str(v)
 
     @field_validator("token_version")
     @classmethod


### PR DESCRIPTION
## Problem

YAML parses unquoted numeric values as integers:

```yaml
users:
  alice:
    password: 12345   # parsed as int by PyYAML
```

Pydantic v2 rejects `int` for a bare `str` field, raising a `ValidationError` at startup. Users with numeric-looking passwords or client secrets hit this immediately.

## Fix

Add `mode="before"` validators on `UserRecord.password` and `ServicePrincipalRecord.secret` that call `str(v)` before type validation. Any YAML scalar (int, float, bool) is safely coerced.

## Test plan

- [x] 41/41 tests passing
- [x] `UserRecord.model_validate({'password': 12345})` → `password == '12345'`
- [x] `ServicePrincipalRecord.model_validate({'secret': 99999})` → `secret == '99999'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)