### PR TITLE
feat: multi-key JWKS with decoy keys (v0.3.5)

### DIFF
--- a/src/mock_idp/keys.py
+++ b/src/mock_idp/keys.py
@@ -10,7 +10,8 @@ def key_kid(key: JsonWebKey) -> str:
 
 
 _signing_key = _new_key("mock-py-1")
-_alt_key = _new_key("mock-py-alt")  # never published; used by wrong-sig endpoint
+_alt_key = _new_key("mock-py-alt")      # never published; used by wrong-sig endpoint
+_decoy_keys = [_new_key("mock-py-d1"), _new_key("mock-py-d2")]  # published but never sign
 
 
 def get_signing_key() -> JsonWebKey:
@@ -19,6 +20,11 @@ def get_signing_key() -> JsonWebKey:
 
 def get_alt_key() -> JsonWebKey:
     return _alt_key
+
+
+def get_jwks_keys() -> list[JsonWebKey]:
+    """Active signing key first, then decoys — tests the gateway's kid-based selection."""
+    return [_signing_key] + _decoy_keys
 
 
 def rotate() -> JsonWebKey:

--- a/src/mock_idp/routers/oidc.py
+++ b/src/mock_idp/routers/oidc.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from .. import config as _cfg
-from ..keys import get_alt_key, get_signing_key
+from ..keys import get_alt_key, get_jwks_keys, get_signing_key
 from ..providers import get_provider
 from ..tokens import (
     apply_overrides,
@@ -49,7 +49,7 @@ async def discovery(issuer: str, request: Request):
 async def jwks(issuer: str, request: Request):
     headers = {k.lower(): v for k, v in request.headers.items()}
     await apply_test_hooks(headers)
-    return {"keys": [get_signing_key().as_dict(is_private=False)]}
+    return {"keys": [k.as_dict(is_private=False) for k in get_jwks_keys()]}
 
 
 @router.post("/{issuer}/token")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -48,8 +48,22 @@ def test_jwks(client):
     r = client.get("/default/jwks")
     assert r.status_code == 200
     keys = r.json()["keys"]
-    assert len(keys) == 1
-    assert keys[0]["kty"] == "RSA"
+    assert len(keys) == 3
+    assert all(k["kty"] == "RSA" for k in keys)
+
+
+def test_jwks_active_kid_matches_token(client):
+    """The kid in the issued token must match the first key in /jwks."""
+    token_r = client.post(
+        "/default/token",
+        data={"grant_type": "password", "username": "alice", "password": "alice-pw",
+              "resource": "api://serviceB"},
+    )
+    token = token_r.json()["access_token"]
+    header = json.loads(b64urlDecode_str(token.split(".")[0]))
+    jwks_kids = [k["kid"] for k in client.get("/default/jwks").json()["keys"]]
+    assert header["kid"] == jwks_kids[0]
+    assert header["kid"] not in jwks_kids[1:]
 
 
 # ── Password grant ─────────────────────────────────────────────────────────
@@ -632,3 +646,8 @@ def _decode_payload(token: str) -> dict:
     part = token.split(".")[1]
     part += "=" * (-len(part) % 4)
     return json.loads(base64.urlsafe_b64decode(part))
+
+
+def b64urlDecode_str(s: str) -> str:
+    s += "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s).decode()


### PR DESCRIPTION
## Summary

`/jwks` now returns 3 RSA keys: the active signing key first, followed by 2 decoy keys with distinct `kid`s that are never used to sign tokens.

This lets you confirm that your gateway correctly selects the key by `kid` rather than blindly using the first or only key in the set.

## Test plan

- [x] 42/42 tests passing
- [x] `test_jwks` — asserts 3 keys returned, all RSA
- [x] `test_jwks_active_kid_matches_token` — token `kid` matches first JWKS key, not decoys

🤖 Generated with [Claude Code](https://claude.com/claude-code)