### PR TITLE
feat: user token aud = app_id UUID; SP token aud = URI (Entra ID fidelity)

### DIFF
--- a/src/mock_idp/routers/oidc.py
+++ b/src/mock_idp/routers/oidc.py
@@ -16,6 +16,7 @@ from ..tokens import (
     resolve_expiry,
     resolve_roles,
     resolve_shape,
+    resolve_user_aud,
     sign,
 )
 
@@ -70,7 +71,8 @@ async def token(issuer: str, request: Request):
         shape = resolve_shape(user.token_version, form, headers.get("x-token-shape"))
         expires_in = resolve_expiry(user.token_lifetime_seconds, headers)
         roles = resolve_roles(user_key, user, aud)
-        claims = provider.user_claims(issuer, user, aud, shape, expires_in, roles, form.get("client_id"))
+        token_aud = resolve_user_aud(aud)  # UUID for user tokens; URI unchanged for SPs
+        claims = provider.user_claims(issuer, user, token_aud, shape, expires_in, roles, form.get("client_id"))
 
     elif grant_type == "client_credentials":
         sp_key = form.get("client_id") or ""

--- a/src/mock_idp/tokens.py
+++ b/src/mock_idp/tokens.py
@@ -41,6 +41,20 @@ def resolve_aud(form: dict) -> str:
     return "api://default"
 
 
+def resolve_user_aud(aud: str) -> str:
+    """Return the app_id UUID for user tokens when the client app defines one.
+
+    Entra ID sets aud to the bare UUID (app_id) for user tokens and to the
+    Application ID URI (api://...) for service-principal tokens. If no
+    ClientAppRecord exists for this audience, or it has no app_id, return
+    the URI unchanged so behaviour stays backward-compatible.
+    """
+    app = _cfg.CLIENT_APPS.get(aud)
+    if app and app.app_id:
+        return app.app_id
+    return aud
+
+
 def resolve_expiry(default: int, headers: dict) -> int:
     if headers.get("x-test-expired"):
         return -60

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -83,7 +83,7 @@ def test_password_grant_happy_path(client):
     data = r.json()
     assert "access_token" in data
     payload = _decode_payload(data["access_token"])
-    assert payload["aud"] == "api://serviceB"
+    assert payload["aud"] == "01010101-1010-1010-1010-bbbbbbbbbbbb"
     assert payload["preferred_username"] == "alice@example.com"
     assert payload["ver"] == "2.0"
     assert "operator" in payload["roles"]
@@ -255,7 +255,7 @@ def test_aud_from_resource(client):
             "resource": "api://serviceB",
         },
     )
-    assert _decode_payload(r.json()["access_token"])["aud"] == "api://serviceB"
+    assert _decode_payload(r.json()["access_token"])["aud"] == "01010101-1010-1010-1010-bbbbbbbbbbbb"
 
 
 def test_aud_from_scope_default_suffix(client):
@@ -268,7 +268,25 @@ def test_aud_from_scope_default_suffix(client):
             "scope": "api://serviceB/.default",
         },
     )
-    assert _decode_payload(r.json()["access_token"])["aud"] == "api://serviceB"
+    assert _decode_payload(r.json()["access_token"])["aud"] == "01010101-1010-1010-1010-bbbbbbbbbbbb"
+
+
+def test_user_aud_resolves_to_app_id_uuid(client):
+    """User tokens carry the app_id UUID as aud; SP tokens carry the URI."""
+    user_r = client.post(
+        "/default/token",
+        data={"grant_type": "password", "username": "alice", "password": "alice-pw",
+              "resource": "api://serviceB"},
+    )
+    sp_r = client.post(
+        "/default/token",
+        data={"grant_type": "client_credentials", "client_id": "service-a",
+              "client_secret": "serviceA-secret", "resource": "api://serviceB"},
+    )
+    user_aud = _decode_payload(user_r.json()["access_token"])["aud"]
+    sp_aud = _decode_payload(sp_r.json()["access_token"])["aud"]
+    assert user_aud == "01010101-1010-1010-1010-bbbbbbbbbbbb"  # app_id UUID
+    assert sp_aud == "api://serviceB"                          # URI unchanged
 
 
 def test_aud_resource_wins_over_scope(client):
@@ -282,7 +300,7 @@ def test_aud_resource_wins_over_scope(client):
             "scope": "api://serviceC/.default",
         },
     )
-    assert _decode_payload(r.json()["access_token"])["aud"] == "api://serviceB"
+    assert _decode_payload(r.json()["access_token"])["aud"] == "01010101-1010-1010-1010-bbbbbbbbbbbb"
 
 
 def test_aud_default_when_neither(client):


### PR DESCRIPTION
## Summary

Entra ID issues tokens differently based on grant type:
- **User tokens** (`password` grant) → `aud` = bare UUID (`app_id` from the resource app registration)
- **SP tokens** (`client_credentials`) → `aud` = Application ID URI (`api://...`)

The `app_id` field already existed on `ClientAppRecord` but was unused. This wires it in via `resolve_user_aud()` in `tokens.py` — called only on the password grant path.

**Backward compatible:** if no `ClientAppRecord` exists for the audience, or it has no `app_id`, the URI passes through unchanged.

## Impact on existing configs

Any config with `app_id` set on `clients:` entries will now issue user tokens with a UUID `aud`. If your gateway validates `aud` against the URI, add `app_id` to match what you expect — or omit `app_id` to keep the old URI behaviour.

## Test plan

- [x] 43/43 tests passing
- [x] `test_user_aud_resolves_to_app_id_uuid` — side-by-side assertion of UUID vs URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)