### PR TITLE
feat: per-issuer auth_mode overrides (v0.3.6)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,12 @@ auth_mode: lax
 cors_allow_origins: ["*"]
 admin_token: change-me-in-real-deployments
 
+# Per-issuer auth_mode overrides. The URL slug (e.g. /strict-issuer/token)
+# maps to "lax" or "strict", overriding the global auth_mode above.
+# issuer_modes:
+#   strict-issuer: strict
+#   permissive-issuer: lax
+
 tenants:
   22222222-2222-2222-2222-222222222222:
     provider: entra_id

--- a/src/mock_idp/config.py
+++ b/src/mock_idp/config.py
@@ -19,6 +19,7 @@ def _load_config(path: Path) -> AppConfig:
 
 _config = _load_config(CONFIG_PATH)
 MODE: str = _config.auth_mode
+ISSUER_MODES: dict[str, str] = _config.issuer_modes
 # Env var takes precedence so the token can live in a Kubernetes Secret
 # without touching the ConfigMap.
 ADMIN_TOKEN: str = os.getenv("MOCK_IDP_ADMIN_TOKEN") or _config.admin_token

--- a/src/mock_idp/models.py
+++ b/src/mock_idp/models.py
@@ -82,6 +82,7 @@ class AppConfig(BaseModel):
     auth_mode: str = "lax"
     cors_allow_origins: list[str] = ["*"]
     admin_token: str = "change-me"
+    issuer_modes: dict[str, str] = {}  # per-issuer-slug auth_mode overrides
     tenants: dict[str, TenantRecord] = {}
 
     @field_validator("auth_mode")
@@ -91,6 +92,17 @@ class AppConfig(BaseModel):
         if v not in ("lax", "strict"):
             raise ValueError("auth_mode must be 'lax' or 'strict'")
         return v
+
+    @field_validator("issuer_modes")
+    @classmethod
+    def _valid_issuer_modes(cls, v: dict) -> dict:
+        result = {}
+        for slug, mode in v.items():
+            mode = str(mode).lower()
+            if mode not in ("lax", "strict"):
+                raise ValueError(f"issuer_modes[{slug!r}] must be 'lax' or 'strict'")
+            result[slug] = mode
+        return result
 
 
 class DecodeRequest(BaseModel):

--- a/src/mock_idp/routers/oidc.py
+++ b/src/mock_idp/routers/oidc.py
@@ -61,13 +61,14 @@ async def token(issuer: str, request: Request):
     grant_type = form.get("grant_type")
     aud = resolve_aud(form)
     provider = get_provider("entra_id")
+    effective_mode = _cfg.ISSUER_MODES.get(issuer) or _cfg.MODE
 
     if grant_type == "password":
         user_key = form.get("username") or ""
         user = _cfg.USERS.get(user_key)
         if not user or user.password != form.get("password"):
             raise HTTPException(401, "invalid_grant")
-        check_audience(user_key, user, aud)
+        check_audience(user_key, user, aud, mode=effective_mode)
         shape = resolve_shape(user.token_version, form, headers.get("x-token-shape"))
         expires_in = resolve_expiry(user.token_lifetime_seconds, headers)
         roles = resolve_roles(user_key, user, aud)
@@ -79,7 +80,7 @@ async def token(issuer: str, request: Request):
         sp = _cfg.SERVICE_PRINCIPALS.get(sp_key)
         if not sp or sp.secret != form.get("client_secret"):
             raise HTTPException(401, "invalid_client")
-        check_audience(sp_key, sp, aud)
+        check_audience(sp_key, sp, aud, mode=effective_mode)
         shape = resolve_shape(sp.token_version, form, headers.get("x-token-shape"))
         expires_in = resolve_expiry(sp.token_lifetime_seconds, headers)
         roles = resolve_roles(sp_key, sp, aud)
@@ -106,13 +107,14 @@ async def token_wrong_sig(issuer: str, request: Request):
     headers = {k.lower(): v for k, v in request.headers.items()}
     aud = resolve_aud(form)
     provider = get_provider("entra_id")
+    effective_mode = _cfg.ISSUER_MODES.get(issuer) or _cfg.MODE
 
     if form.get("grant_type") == "password":
         user_key = form.get("username") or ""
         user = _cfg.USERS.get(user_key)
         if not user or user.password != form.get("password"):
             raise HTTPException(401, "invalid_grant")
-        check_audience(user_key, user, aud)
+        check_audience(user_key, user, aud, mode=effective_mode)
         shape = resolve_shape(user.token_version, form, headers.get("x-token-shape"))
         roles = resolve_roles(user_key, user, aud)
         claims = provider.user_claims(issuer, user, aud, shape, 3600, roles, form.get("client_id"))
@@ -121,7 +123,7 @@ async def token_wrong_sig(issuer: str, request: Request):
         sp = _cfg.SERVICE_PRINCIPALS.get(sp_key)
         if not sp or sp.secret != form.get("client_secret"):
             raise HTTPException(401, "invalid_client")
-        check_audience(sp_key, sp, aud)
+        check_audience(sp_key, sp, aud, mode=effective_mode)
         shape = resolve_shape(sp.token_version, form, headers.get("x-token-shape"))
         roles = resolve_roles(sp_key, sp, aud)
         claims = provider.sp_claims(issuer, sp._canonical_id, sp, aud, shape, 3600, roles)

--- a/src/mock_idp/tokens.py
+++ b/src/mock_idp/tokens.py
@@ -84,8 +84,14 @@ def resolve_roles(identity_key: str, identity: UserRecord | ServicePrincipalReco
     return list(identity.roles)
 
 
-def check_audience(identity_key: str, identity: UserRecord | ServicePrincipalRecord, aud: str) -> None:
-    if _cfg.MODE != "strict":
+def check_audience(
+    identity_key: str,
+    identity: UserRecord | ServicePrincipalRecord,
+    aud: str,
+    mode: Optional[str] = None,
+) -> None:
+    effective_mode = mode if mode in ("lax", "strict") else _cfg.MODE
+    if effective_mode != "strict":
         return
     if isinstance(identity, ServicePrincipalRecord) and identity.override_any_claim:
         return

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -377,6 +377,46 @@ def test_strict_mode_rejects_identity_without_grant(client):
         m.MODE = original
 
 
+# ── Per-issuer auth_mode ───────────────────────────────────────────────────
+
+
+def test_per_issuer_strict_overrides_global_lax(client):
+    """An issuer slug mapped to strict rejects unlisted audiences even when global is lax."""
+    import mock_idp.config as m
+
+    assert m.MODE == "lax"
+    m.ISSUER_MODES["strict-slug"] = "strict"
+    try:
+        r = client.post(
+            "/strict-slug/token",
+            data={"grant_type": "password", "username": "bob", "password": "bob-pw",
+                  "resource": "api://serviceC"},
+        )
+        assert r.status_code == 400
+        assert r.json()["detail"]["error"] == "invalid_target"
+    finally:
+        m.ISSUER_MODES.pop("strict-slug", None)
+
+
+def test_per_issuer_lax_overrides_global_strict(client):
+    """An issuer slug mapped to lax allows any audience even when global is strict."""
+    import mock_idp.config as m
+
+    original = m.MODE
+    m.MODE = "strict"
+    m.ISSUER_MODES["lax-slug"] = "lax"
+    try:
+        r = client.post(
+            "/lax-slug/token",
+            data={"grant_type": "password", "username": "alice", "password": "alice-pw",
+                  "resource": "api://anything-goes"},
+        )
+        assert r.status_code == 200
+    finally:
+        m.MODE = original
+        m.ISSUER_MODES.pop("lax-slug", None)
+
+
 # ── Admin override ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Add `issuer_modes:` to the top-level config — a map from issuer URL slug to `lax` or `strict`, overriding the global `auth_mode` for requests arriving at that path.

```yaml
auth_mode: lax          # global default

issuer_modes:
  strict-issuer: strict  # POST /strict-issuer/token enforces grants
  permissive: lax        # POST /permissive/token always lax
```

`check_audience()` gains an optional `mode` param; the router resolves the effective mode per request via `_cfg.ISSUER_MODES.get(issuer) or _cfg.MODE`.

## Test plan

- [x] 45/45 tests passing
- [x] `test_per_issuer_strict_overrides_global_lax` — strict slug rejects bob/serviceC while global is lax
- [x] `test_per_issuer_lax_overrides_global_strict` — lax slug allows any audience while global is strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)